### PR TITLE
Support masks from higher dimensional sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ from regional import one
 region = one([[0, 0], [0, 1], [1, 0], [1, 1]])
 
 region.bbox
->> [0, 0, 1, 1]
+>> [[0, 1], [0, 1]]
 
 region.center
 >> [0.5, 0.5]

--- a/regional/__init__.py
+++ b/regional/__init__.py
@@ -1,3 +1,3 @@
 from .regional import (one, many)
 
-__version__ = '1.0.1'
+__version__ = '1.0.2'

--- a/regional/regional.py
+++ b/regional/regional.py
@@ -481,7 +481,7 @@ def getbase(base=None, dims=None, extent=None, background=None):
         for channel in range(3):
             base[[slice(0,i) for i in base.shape[0:-1]] + [channel]] = background[channel]
         return base
-    elif base is not None and (base.ndim < 3 or not (base.shape[-1] == 3 or base.shape[-1] == 4)):
+    elif base is not None and (base.ndim < 3 or not base.shape[-1] == 3):
         return tile(expand_dims(base, base.ndim), concatenate((ones(base.ndim, dtype=int), [3])))
     else:
         return base

--- a/regional/regional.py
+++ b/regional/regional.py
@@ -1,4 +1,4 @@
-from numpy import asarray, amin, amax, sqrt, concatenate, \
+from numpy import asarray, amin, amax, sqrt, concatenate, stack, \
     mean, ndarray, sum, all, ones, tile, expand_dims, zeros, where, integer
 import checkist
 
@@ -41,7 +41,7 @@ class one(object):
         """
         mn = amin(self.coordinates, axis=0)
         mx = amax(self.coordinates, axis=0)
-        return concatenate((mn, mx))
+        return stack((mn, mx), axis=1)
 
     @property
     def area(self):
@@ -55,7 +55,8 @@ class one(object):
         """
         Total region extent.
         """
-        return self.bbox[2:] - self.bbox[0:2] + 1
+
+        return self.bbox[:,1] - self.bbox[:,0] + 1
     
     def distance(self, other):
         """
@@ -163,10 +164,10 @@ class one(object):
             size = (size * 2) + 1
             coords = self.coordinates
             tmp = zeros(self.extent + size * 2)
-            coords = (coords - self.bbox[0:len(self.center)] + size)
+            coords = (coords - self.bbox[:,0] + size)
             tmp[coords.T.tolist()] = 1
             tmp = binary_dilation(tmp, ones((size, size)))
-            new = asarray(where(tmp)).T + self.bbox[0:len(self.center)] - size
+            new = asarray(where(tmp)).T + self.bbox[:,0] - size
             new = [c for c in new if all(c >= 0)]
         else:
             return self
@@ -240,7 +241,7 @@ class one(object):
         background = getcolor(background)
 
         if dims is None and base is None:
-            region = one(self.coordinates - self.bbox[0:2])
+            region = one(self.coordinates - self.bbox[:,0])
         else:
             region = self
 
@@ -407,8 +408,8 @@ class many(object):
         stroke = getcolors(stroke, self.count)
         fill = getcolors(fill, self.count, cmap, value)
 
-        minbound = asarray([b[0:2] for b in self.bbox]).min(axis=0)
-        maxbound = asarray([b[2:] for b in self.bbox]).max(axis=0)
+        minbound = asarray([b[:,0] for b in self.bbox]).min(axis=0)
+        maxbound = asarray([b[:,1] for b in self.bbox]).max(axis=0)
         extent = maxbound - minbound + 1
 
         if dims is None and base is None:


### PR DESCRIPTION
This PR adds support for making masks of arbitrary dimensional sources and base images.
Previously support was provided only for 2D sources. A base image of the same dimensionality of the sources can now be provided to mask.

If a 3D (or larger) base image with final dimension of size 3 is provided this base image will be treated as an rgb base. The dimensionality of the base should therefore be one larger than the dimensionality of the sources.

This PR also reshapes the bounding box so that it is a 2D array rather than a concatenated 1D array. The docs have been changed to reflect this, and the version number has been bumped to 1.0.2
